### PR TITLE
Fix for (new?) behavior of readr::parse_number()

### DIFF
--- a/R/bullet-scores.R
+++ b/R/bullet-scores.R
@@ -142,8 +142,10 @@ bullet_to_land_predict <- function(land1, land2, scores, difference, alpha = 0.0
     # pick the maximum to determine the phase
     idx <- which.max(avgs)
     dd <- data.frame(
-      land1 = parse_number(land1),
-      land2 = parse_number(land2))
+      land1,
+      land2
+    ) %>%
+        mutate_if(function(.) !is.numeric(.), parse_number)
     dd$diff = (dd$land1 - dd$land2) %% p + 1
 
 

--- a/R/bullet-scores.R
+++ b/R/bullet-scores.R
@@ -65,8 +65,8 @@
 #'   )
 #' }
 compute_average_scores <- function(land1, land2, score) {
-  land1 <- readr::parse_number(land1)
-  land2 <- readr::parse_number(land2)
+  if (!is.numeric(land1)) land1 <- readr::parse_number(land1)
+  if (!is.numeric(land2)) land2 <- readr::parse_number(land2)
   assert_that(is.numeric(land1), is.numeric(land2), is.numeric(score))
 
   maxland <- max(land1, land2)
@@ -124,8 +124,8 @@ bootstrap_k <- function(scores, k, K, value) {
 #' @export
 #' @return numeric vector of binary prediction whether two lands are same-source. Vector has the same length as the input vectors.
 bullet_to_land_predict <- function(land1, land2, scores, difference, alpha = 0.05) {
-  land1 <- readr::parse_number(land1)
-  land2 <- readr::parse_number(land2)
+  if (!is.numeric(land1)) land1 <- readr::parse_number(land1)
+  if (!is.numeric(land2)) land2 <- readr::parse_number(land2)
   avgs <- compute_average_scores(land2, land1, scores)
 
     p <- max(c(land1, land2))


### PR DESCRIPTION
As i was working on the book chapter, I noticed that the very end of the readme was failing for me... it appears that the latest parse_number() function from readr will fail if the input is **already a numeric value**. Reproducible example:

> parse_number(4)

> Error in parse_vector(x, col_number(), na = na, locale = locale, trim_ws = trim_ws) : 
>   is.character(x) is not TRUE

Therefore, the bullet_to_land_predict function, which calls parse number and then passes it to compute_average_scores (which also calls parse_number) was failing for me. Here is a simple check that just says only do this if the input is not already numeric. This fixed the issue for me, but if there's anything i'm missing let me know, and there may be better ways to solve it than this.