### PR TITLE
fix: `phase_test()` now correctly ranks phases

### DIFF
--- a/R/phase_test.R
+++ b/R/phase_test.R
@@ -35,13 +35,14 @@ phase_test <- function(land1, land2, score, sigma_0 = NA, alpha = 0.05) {
     summarize(
       means = mean(score, na.rm = TRUE)
     ) %>% ungroup() %>%
+    arrange(means) %>%
     mutate(
-      ordered = (1:n)[order(.data$means)]
-    ) %>% arrange(means)
-  dframe <- dframe %>% mutate(
-    phase = avgs$ordered[.data$phase]
-  )
-
+      ordered = (1:n)
+    )
+  dframe <- dframe %>%
+    left_join(avgs %>% select(phase, ordered), by = "phase") %>%
+    mutate(phase = ordered) %>%  # overwrite phase with ordered
+    select(-ordered)
 
   est1 <- avgs$means[n]
   est2 <- avgs$means[floor(n/2)]


### PR DESCRIPTION
Fixes #16. Changed the way that the helper data frames `avgs` and `dframe` are calculated so that the highest rank is now correctly assigned to the phase with the highest mean. This, in turn, fixes the `sigmas` data frame so that it now correctly labels the phase with the highest mean as in-phase.